### PR TITLE
Feature - Single Port Mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 sudo: false
+go_import_path: github.com/vcabbage/trivialt
 go:
  - 1.5.4
  - 1.6.2
@@ -12,7 +13,7 @@ before_install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/modocache/gover
 script:
-  - go test -v -covermode=count -coverprofile=trivialt.coverprofile . 
-  - go test -v -covermode=count -coverprofile=netascii.coverprofile ./netascii 
+  - go test -v -covermode=count -coverprofile=trivialt.coverprofile .
+  - go test -v -covermode=count -coverprofile=netascii.coverprofile ./netascii
   - gover
   - goveralls -coverprofile=gover.coverprofile -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ trivialt is a cross-platform, concurrent TFTP server and client. It can be used 
 
 - [X] Binary Transfer ([RFC 1350](https://tools.ietf.org/html/rfc1350))
 - [X] Netascii Transfer ([RFC 1350](https://tools.ietf.org/html/rfc1350))
-- [X] Option Extention ([RFC 2347](https://tools.ietf.org/html/rfc2347))
+- [X] Option Extension ([RFC 2347](https://tools.ietf.org/html/rfc2347))
 - [X] Blocksize Option ([RFC 2348](https://tools.ietf.org/html/rfc2348))
 - [X] Timeout Interval Option ([RFC 2349](https://tools.ietf.org/html/rfc2349))
 - [X] Transfer Size Option ([RFC 2349](https://tools.ietf.org/html/rfc2349))
@@ -23,19 +23,19 @@ trivialt is a cross-platform, concurrent TFTP server and client. It can be used 
 
 ### Unique Features
 
-- Single Port Mode
+- __Single Port Mode__
 
     TL;DR: It allows TFTP to work through firewalls.
 
     A standard TFTP server implementation receives requests on port 69 and allocates a new high port (over 1024) dedicated to that request.
-    In single port mode, trivialt receives and responds to requests on the same port. If are server is started on port 69, all communication will
+    In single port mode, trivialt receives and responds to requests on the same port. If trivialt is started on port 69, all communication will
     be done on port 69.
     
     The primary use case of this feature is to play nicely with firewalls. Most firewalls will prevent the typical case where the server responds
     back on a random port because they have no way of knowing that it is in response to a request that went out on port 69. In single port mode,
     the firewall will see a request go out to a server on port 69 and that server respond back on the same port, which most firewalls will allow.
     
-    Of course if the firewall in question is configured the block TFTP connections, this setting won't help you.
+    Of course if the firewall in question is configured to block TFTP connections, this setting won't help you.
     
     Enable single port mode with the `--single-port` flag. This is currently marked experimental as is diverges from the TFTP standard.
 
@@ -70,7 +70,8 @@ DESCRIPTION:
    the current directory.
 
 OPTIONS:
-   --writeable, -w	Enable file upload.
+   --writeable, -w	    Enable file upload.
+   --single-port, --sp	Enable single port mode. [Experimental]
 ```
 
 ```
@@ -145,10 +146,10 @@ trivialt's API was inspired by Go's well-known net/http API. If you can write a 
 
 ### Configuration Functions
 
-One area that is noticably different from net/http is the configuration of clients and servers. trivialt uses "configuration functions" rather than the direct modification of the
+One area that is noticeably different from net/http is the configuration of clients and servers. trivialt uses "configuration functions" rather than the direct modification of the
 Client/Server struct or a configuration struct passed into the factory functions.
 
-A few explainations of this pattern:
+A few explanations of this pattern:
 * [Self-referential functions and the design of options](http://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html) by Rob Pike
 * [Functional options for friendly APIs](https://www.youtube.com/watch?v=24lFtGHWxAQ) by Dave Cheney [video]
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ trivialt is a cross-platform, concurrent TFTP server and client. It can be used 
 - [X] Transfer Size Option ([RFC 2349](https://tools.ietf.org/html/rfc2349))
 - [X] Windowsize Option ([RFC 7440](https://tools.ietf.org/html/rfc7440))
 
+### Unique Features
+
+- Single Port Mode
+
+    TL;DR: It allows TFTP to work through firewalls.
+
+    A standard TFTP server implementation receives requests on port 69 and allocates a new high port (over 1024) dedicated to that request.
+    In single port mode, trivialt receives and responds to requests on the same port. If are server is started on port 69, all communication will
+    be done on port 69.
+    
+    The primary use case of this feature is to play nicely with firewalls. Most firewalls will prevent the typical case where the server responds
+    back on a random port because they have no way of knowing that it is in response to a request that went out on port 69. In single port mode,
+    the firewall will see a request go out to a server on port 69 and that server respond back on the same port, which most firewalls will allow.
+    
+    Of course if the firewall in question is configured the block TFTP connections, this setting won't help you.
+    
+    Enable single port mode with the `--single-port` flag. This is currently marked experimental as is diverges from the TFTP standard.
+
 ## Installation
 
 If you have the Go toolchain installed you can simply `go get` the packages. This will download the source into your `$GOPATH` and install the binary to `$GOPATH/bin/trivialt`.

--- a/cmd/trivialt/main.go
+++ b/cmd/trivialt/main.go
@@ -80,6 +80,10 @@ func main() {
 					Name:  "writable, w",
 					Usage: "Enable file upload.",
 				},
+				cli.BoolFlag{
+					Name:  "single-port, sp",
+					Usage: "Enable single port mode. [Experimental]",
+				},
 			},
 			Description: `Serves files from the local file systemd.
    
@@ -119,6 +123,7 @@ func cmdServe(c *cli.Context) {
 	addr := c.Args().First()
 	path := c.Args().Get(1)
 	writable := c.Bool("writable")
+	singlePort := c.Bool("single-port")
 
 	if addr == "" {
 		addr = ":69"
@@ -132,7 +137,7 @@ func cmdServe(c *cli.Context) {
 	log.Printf("Starting TFTP Server on %q, serving %q\n", addr, root)
 	fs := &server{trivialt.FileServer(root)}
 
-	server, err := trivialt.NewServer(addr)
+	server, err := trivialt.NewServer(addr, trivialt.ServerSinglePort(singlePort))
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/conn.go
+++ b/conn.go
@@ -50,14 +50,13 @@ func newConn(udpNet string, mode transferMode, addr *net.UDPAddr) (*conn, error)
 		windowsize: defaultWindowsize,
 		retransmit: defaultRetransmit,
 		mode:       mode,
-		buf:        make([]byte, 4+defaultBlksize), // +4 for headers
 	}
 	c.rx.buf = make([]byte, 4+defaultBlksize) // +4 for headers
 
 	return c, nil
 }
 
-func newSinglePortConn(addr *net.UDPAddr, netConn *net.UDPConn, reqChan chan []byte) *conn {
+func newSinglePortConn(addr *net.UDPAddr, mode transferMode, netConn *net.UDPConn, reqChan chan []byte) *conn {
 	return &conn{
 		log:        newLogger(addr.String()),
 		remoteAddr: addr,
@@ -65,6 +64,7 @@ func newSinglePortConn(addr *net.UDPAddr, netConn *net.UDPConn, reqChan chan []b
 		timeout:    defaultTimeout,
 		windowsize: defaultWindowsize,
 		retransmit: defaultRetransmit,
+		mode:       mode,
 		buf:        make([]byte, 4+defaultBlksize), // +4 for headers
 		reqChan:    reqChan,
 		netConn:    netConn,

--- a/conn.go
+++ b/conn.go
@@ -785,9 +785,8 @@ func (c *conn) readFromNet() (net.Addr, error) {
 
 		// Single port mode
 		select {
-		case data := <-c.reqChan:
-			n := copy(c.rx.buf, data)
-			c.rx.offset = n
+		case c.rx.buf = <-c.reqChan:
+			c.rx.offset = len(c.rx.buf)
 			return nil, nil
 		case <-c.timer.C:
 			return nil, errors.New("timeout reading from channel")

--- a/conn.go
+++ b/conn.go
@@ -421,7 +421,7 @@ func (c *conn) readSetup() error {
 
 	// Set buf size
 	needed := int(c.blksize + 4)
-	if len(c.buf) != needed {
+	if len(c.rx.buf) != needed {
 		c.rx.buf = make([]byte, needed)
 	}
 
@@ -601,6 +601,7 @@ func (c *conn) Close() (err error) {
 
 	// netasciiEnc needs to be flushed if it's in use
 	if c.netasciiEnc != nil {
+		c.log.trace("Flushing netascii encoder")
 		if err := c.netasciiEnc.Flush(); err != nil {
 			return wrapError(err, "flushing netascii encoder before Close")
 		}

--- a/conn_test.go
+++ b/conn_test.go
@@ -82,7 +82,7 @@ func TestNewConn(t *testing.T) {
 		if conn.retransmit != 10 {
 			t.Errorf("%s: Expected retransmit to be default 1, but it was %d", label, conn.retransmit)
 		}
-		if len(conn.buf) != 516 {
+		if len(conn.rx.buf) != 516 {
 			t.Errorf("%s: Expected buf len to be default 516, but it was %d", label, len(conn.buf))
 		}
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -655,8 +655,8 @@ func TestConn_sendReadRequest(t *testing.T) {
 				t.Errorf("%s: Expected tsize to be %d, but it was %d", label, *c.expectedTsize, *tConn.tsize)
 			}
 		}
-		if len(tConn.buf) != c.expectedBufLen {
-			t.Errorf("%s: Expected buf len to be %d, but it was %d", label, c.expectedBufLen, len(tConn.buf))
+		if len(tConn.rx.buf) != c.expectedBufLen {
+			t.Errorf("%s: Expected buf len to be %d, but it was %d", label, c.expectedBufLen, len(tConn.rx.buf))
 		}
 	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -225,6 +225,19 @@ func TestConn_getAck(t *testing.T) {
 			expectedRingBuf: -4,
 			expectedError:   "^$",
 		},
+		"incorrect block, ahead": {
+			timeout: time.Second * 1,
+			block:   18,
+			window:  5,
+			connFunc: func(label string, conn *net.UDPConn, sAddr *net.UDPAddr) {
+				tDG.writeAck(20)
+				testWriteConn(t, conn, sAddr, tDG)
+			},
+
+			expectedBlock:  18,
+			expectedWindow: 5,
+			expectedError:  "^$",
+		},
 	}
 
 	for label, c := range cases {
@@ -233,7 +246,7 @@ func TestConn_getAck(t *testing.T) {
 		tConn.timeout = c.timeout
 		tConn.block = c.block
 		tConn.window = c.window
-		tConn.buf = make([]byte, 516)
+		tConn.rx.buf = make([]byte, 516)
 		tConn.txBuf = newRingBuffer(100, 100)
 
 		var wg sync.WaitGroup

--- a/server.go
+++ b/server.go
@@ -245,7 +245,9 @@ func (s *Server) newConn(addr *net.UDPAddr, buf []byte) (*conn, func() error, er
 
 	closer := func() error {
 		err := c.Close()
-		s.mgr.Remove(addr)
+		if s.singlePort {
+			s.mgr.Remove(addr)
+		}
 		return err
 	}
 

--- a/server.go
+++ b/server.go
@@ -230,7 +230,7 @@ func (s *Server) newConn(addr *net.UDPAddr, buf []byte) (*conn, func() error, er
 	}
 
 	if s.singlePort {
-		c = newSinglePortConn(addr, s.conn, s.mgr.New(addr))
+		c = newSinglePortConn(addr, dg.mode(), s.conn, s.mgr.New(addr))
 	} else {
 		c, err = newConn(s.net, dg.mode(), addr) // Use empty mode until request has been parsed.
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -106,7 +106,7 @@ func (s *Server) Serve(conn *net.UDPConn) error {
 
 	s.conn = conn
 
-	buf := make([]byte, 65536)
+	buf := make([]byte, 65536) // Largest possible TFTP datagram
 	for {
 		numBytes, addr, err := conn.ReadFromUDP(buf)
 		if err != nil {
@@ -115,9 +115,19 @@ func (s *Server) Serve(conn *net.UDPConn) error {
 			}
 			return wrapError(err, "reading from conn")
 		}
-		dg := datagram{buf: make([]byte, numBytes)}
-		dg.offset = copy(dg.buf, buf[:numBytes])
-		go s.dispatchRequest(addr, &dg)
+
+		// Make a copy of the recieved data
+		b := make([]byte, numBytes)
+		copy(b, buf)
+
+		switch buf[1] {
+		case 1: //RRQ
+			go s.dispatchReadRequest(addr, b)
+		case 2: //WRQ
+			go s.dispatchWriteRequest(addr, b)
+		default:
+			go s.demuxToConn(addr, b)
+		}
 	}
 }
 
@@ -127,102 +137,118 @@ func (s *Server) Close() error {
 	return s.conn.Close()
 }
 
-// dispatchRequest parses incoming requests and executes the corresponding
-// handler, if one is registered. If a handler is not registered the server
-// sends an error to the client.
-func (s *Server) dispatchRequest(addr *net.UDPAddr, dg *datagram) {
+// dispatchReadRequest dispatches the read handler, if it is registered.
+// If a handler is not registered the server sends an error to the client.
+func (s *Server) dispatchReadRequest(addr *net.UDPAddr, buf []byte) {
+	// Check for handler
+	if s.rh == nil {
+		s.log.debug("No read handler registered.")
+		var err datagram
+		err.writeError(ErrCodeIllegalOperation, "Server does not support read requests.")
+		_, _ = s.conn.WriteTo(err.bytes(), addr) // Ignore error
+		return
+	}
+
+	c, closer, err := s.newConn(addr, buf)
+	if err != nil {
+		return
+	}
+	defer errorDefer(closer, s.log, "error closing network connection in dispath")
+
+	s.log.debug("New request from %v: %s", addr, c.rx)
+
+	// Create request
+	w := &readRequest{conn: c, name: c.rx.filename()}
+
+	// execute handler
+	s.rh.ServeTFTP(w)
+}
+
+// dispatchWriteRequest dispatches the read handler, if it is registered.
+// If a handler is not registered the server sends an error to the client.
+func (s *Server) dispatchWriteRequest(addr *net.UDPAddr, buf []byte) {
+	// Check for handler
+	if s.wh == nil {
+		s.log.debug("No write handler registered.")
+		var err datagram
+		err.writeError(ErrCodeIllegalOperation, "Server does not support write requests.")
+		_, _ = s.conn.WriteTo(err.bytes(), addr) // Ignore error
+		return
+	}
+
+	c, closer, err := s.newConn(addr, buf)
+	if err != nil {
+		return
+	}
+	defer errorDefer(closer, s.log, "error closing network connection in dispath")
+
+	s.log.debug("New request from %v: %s", addr, c.rx)
+
+	// Create request
+	w := &writeRequest{conn: c, name: c.rx.filename()}
+
+	// parse options to get size
+	c.log.trace("performing write setup")
+	if err := c.readSetup(); err != nil {
+		c.err = err
+	}
+
+	s.wh.ReceiveTFTP(w)
+}
+
+func (s *Server) demuxToConn(addr *net.UDPAddr, buf []byte) {
+	if s.singlePort {
+		if reqChan, ok := s.mgr.Get(addr); ok {
+			reqChan <- buf
+			return
+		}
+	}
+
+	// RFC1350:
+	// "If a source TID does not match, the packet should be
+	// discarded as erroneously sent from somewhere else.  An error packet
+	// should be sent to the source of the incorrect packet, while not
+	// disturbing the transfer."
+	dg := datagram{}
+	dg.writeError(ErrCodeUnknownTransferID, "Unexpected TID")
+	// Don't care about an error here, just a courtesy
+	_, _ = s.conn.WriteTo(dg.bytes(), addr)
+	s.log.debug("Unexpected datagram: %s", dg)
+}
+
+func (s *Server) newConn(addr *net.UDPAddr, buf []byte) (*conn, func() error, error) {
 	var c *conn
 	var err error
+	var dg datagram
+
+	dg.setBytes(buf)
+
 	// Validate request datagram
 	if err := dg.validate(); err != nil {
 		s.log.debug("Error decoding new request: %v", err)
-		return
+		return nil, nil, err
 	}
-	s.log.debug("New request from %v: %s", addr, dg)
 
-	switch dg.opcode() {
-	case opCodeRRQ:
-		// Check for handler
-		if s.rh == nil {
-			s.log.debug("No read handler registered.")
-			c.sendError(ErrCodeIllegalOperation, "Server does not support read requests.")
-			return
+	if s.singlePort {
+		c = newSinglePortConn(addr, s.conn, s.mgr.New(addr))
+	} else {
+		c, err = newConn(s.net, dg.mode(), addr) // Use empty mode until request has been parsed.
+		if err != nil {
+			s.log.err("Received error opening connection for new request: %v", err)
+			return nil, nil, err
 		}
-
-		if s.singlePort {
-			c = newSinglePortConn(addr, s.conn, s.mgr.New(addr))
-			defer s.mgr.Remove(addr)
-		} else {
-			c, err = newConn(s.net, dg.mode(), addr) // Use empty mode until request has been parsed.
-			if err != nil {
-				s.log.err("Received error opening connection for new request: %v", err)
-				return
-			}
-		}
-		defer errorDefer(c.Close, s.log, "error closing network connection in dispath")
-
-		c.rx = *dg
-		// Set retransmit
-		c.retransmit = s.retransmit
-
-		// Create request
-		w := &readRequest{conn: c, name: c.rx.filename()}
-
-		// execute handler
-		s.rh.ServeTFTP(w)
-	case opCodeWRQ:
-		// Check for handler
-		if s.wh == nil {
-			s.log.debug("No write handler registered.")
-			c.sendError(ErrCodeIllegalOperation, "Server does not support write requests.")
-			return
-		}
-
-		if s.singlePort {
-			c = newSinglePortConn(addr, s.conn, s.mgr.New(addr))
-			defer s.mgr.Remove(addr)
-		} else {
-			c, err = newConn(s.net, dg.mode(), addr)
-			if err != nil {
-				s.log.err("Received error opening connection for new request: %v", err)
-				return
-			}
-		}
-		defer errorDefer(c.Close, s.log, "error closing network connection in dispath")
-
-		c.rx = *dg
-		// Set retransmit
-		c.retransmit = s.retransmit
-
-		// Create request
-		w := &writeRequest{conn: c, name: c.rx.filename()}
-
-		// parse options to get size
-		c.log.trace("performing write setup")
-		if err := c.readSetup(); err != nil {
-			c.err = err
-		}
-
-		s.wh.ReceiveTFTP(w)
-	default:
-		if s.singlePort {
-			if reqChan, ok := s.mgr.Get(addr); ok {
-				reqChan <- dg.buf
-				return
-			}
-
-			// RFC1350:
-			// "If a source TID does not match, the packet should be
-			// discarded as erroneously sent from somewhere else.  An error packet
-			// should be sent to the source of the incorrect packet, while not
-			// disturbing the transfer."
-			dg.writeError(ErrCodeUnknownTransferID, "Unexpected TID")
-			// Don't care about an error here, just a courtesy
-			_, _ = s.conn.WriteTo(dg.bytes(), addr)
-		}
-
-		s.log.debug("Unexpected datagram: %s", dg)
 	}
+
+	c.rx = dg
+	// Set retransmit
+	c.retransmit = s.retransmit
+
+	closer := func() error {
+		s.mgr.Remove(addr)
+		return c.Close()
+	}
+
+	return c, closer, nil
 }
 
 // ListenAndServe starts a configured server.

--- a/server.go
+++ b/server.go
@@ -116,7 +116,7 @@ func (s *Server) Serve(conn *net.UDPConn) error {
 			return wrapError(err, "reading from conn")
 		}
 
-		// Make a copy of the recieved data
+		// Make a copy of the received data
 		b := make([]byte, numBytes)
 		copy(b, buf)
 
@@ -301,7 +301,7 @@ func ServerRetransmit(i int) ServerOpt {
 }
 
 // ServerSinglePort enables the server to service all requests via a single port rather
-// than the standard TFTP behavior of each client communicating on a seperate port.
+// than the standard TFTP behavior of each client communicating on a separate port.
 //
 // This is an experimental feature.
 //

--- a/server.go
+++ b/server.go
@@ -244,8 +244,9 @@ func (s *Server) newConn(addr *net.UDPAddr, buf []byte) (*conn, func() error, er
 	c.retransmit = s.retransmit
 
 	closer := func() error {
+		err := c.Close()
 		s.mgr.Remove(addr)
-		return c.Close()
+		return err
 	}
 
 	return c, closer, nil


### PR DESCRIPTION
Single port mode multiplexes all client communication onto the server's main listening port. Tracks connections with a map of strings to channels. The string representation of the remote address is
used as the key. ACK, DATA, and ERRORs are sent on the connection's channel. Calls to conn.readFromNet read off the channel instead of a network connection.
