### PR TITLE
Fix flaky tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
- - 1.6.3
  - 1.7.3
  - tip
 matrix:


### PR DESCRIPTION
Doesn't completely solve occasionally failing tests. Still occasionally get errors like "write udp4 0.0.0.0:55505->127.0.0.1:46408: sendto: operation not permitted" in Jenkins. Can't reproduce on OSX. Possibly related to Linux, Docker, or running on a slower platform.
- Wrap tests which use defer in a function.
- Add conn read/write deadlines.
- Don't call t.Fatal in a separate goroutine.
- Test only on go 1.7 so we can migrate to subtests.
